### PR TITLE
Fix update methods retrieving entity then updating same instance

### DIFF
--- a/CourseManagement.Service/Services/CategoryService.cs
+++ b/CourseManagement.Service/Services/CategoryService.cs
@@ -55,24 +55,32 @@ public class CategoryService: ICategoryService
         }
     }
     
-    public ResultViewModel UpdateCategory(Category category)
-    {
-        try
+        public ResultViewModel UpdateCategory(Category category)
         {
-            var existingCategory = unitOfWork.Category.BuildQuery(c => c.CategoryId == category.CategoryId).FirstOrDefault();
-            existingCategory.CategoryId = category.CategoryId;
-            existingCategory.Name = category.Name;
-            existingCategory.Description = category.Description;
-            existingCategory.SetUpdated();
-            unitOfWork.Category.Update(category);
-            unitOfWork.SaveChange();
-            return ResultViewModel.Success("Update Category Success");
+            try
+            {
+                var existingCategory = unitOfWork.Category
+                    .BuildQuery(c => c.CategoryId == category.CategoryId)
+                    .FirstOrDefault();
+
+                if (existingCategory == null)
+                {
+                    return ResultViewModel.Fail("Category not found");
+                }
+
+                existingCategory.Name = category.Name;
+                existingCategory.Description = category.Description;
+                existingCategory.SetUpdated();
+
+                unitOfWork.Category.Update(existingCategory);
+                unitOfWork.SaveChange();
+                return ResultViewModel.Success("Update Category Success");
+            }
+            catch (Exception ex)
+            {
+                return ResultViewModel.FailException(ex);
+            }
         }
-        catch (Exception ex)
-        {
-            return ResultViewModel.FailException(ex);
-        }
-    }
     
     public ResultViewModel DeleteCategory(string id)
     {

--- a/CourseManagement.Service/Services/ChapterService.cs
+++ b/CourseManagement.Service/Services/ChapterService.cs
@@ -79,13 +79,22 @@ public class ChapterService : IChapterService
     {
         try
         {
-            var existingChapter = unitOfWork.Chapter.BuildQuery(c => c.ChapterId == chapter.ChapterId).FirstOrDefault();
+            var existingChapter = unitOfWork.Chapter
+                .BuildQuery(c => c.ChapterId == chapter.ChapterId)
+                .FirstOrDefault();
+
+            if (existingChapter == null)
+            {
+                return ResultViewModel.Fail("Chapter not found");
+            }
+
             existingChapter.CourseId = chapter.CourseId;
             existingChapter.Title = chapter.Title;
             existingChapter.Description = chapter.Description;
             existingChapter.OrderNumber = chapter.OrderNumber;
             existingChapter.SetUpdated();
-            unitOfWork.Chapter.Update(chapter);
+
+            unitOfWork.Chapter.Update(existingChapter);
             unitOfWork.SaveChange();
             return ResultViewModel.Success("Update chapter successfully");
         }

--- a/CourseManagement.Service/Services/DocumentService.cs
+++ b/CourseManagement.Service/Services/DocumentService.cs
@@ -62,27 +62,37 @@ public class DocumentService: IDocumentService
         }
     }
     
-    public ResultViewModel UpdateDocument(Document document)
-    {
-        try
+        public ResultViewModel UpdateDocument(Document document)
         {
-            var existingDocument = unitOfWork.Document.BuildQuery(d=> d.DocumentId == document.DocumentId).FirstOrDefault();
-            existingDocument.Title = document.Title;
-            existingDocument.DocumentId = document.DocumentId;
-            existingDocument.FilePath = document.FilePath;
-            existingDocument.FileType = document.FileType;
-            existingDocument.LessonId = document.LessonId;
-            existingDocument.SizeInBytes = document.SizeInBytes;
-            existingDocument.SetUpdated();
-            unitOfWork.Document.Update(document);
-            unitOfWork.SaveChange();
-            return ResultViewModel.Success("Document updated successfully", document);
+            try
+            {
+                var existingDocument = unitOfWork.Document
+                    .BuildQuery(d => d.DocumentId == document.DocumentId)
+                    .FirstOrDefault();
+
+                if (existingDocument == null)
+                {
+                    return ResultViewModel.Fail("Document not found");
+                }
+
+                existingDocument.Title = document.Title;
+                existingDocument.FilePath = document.FilePath;
+                existingDocument.FileType = document.FileType;
+                existingDocument.LessonId = document.LessonId;
+                existingDocument.SizeInBytes = document.SizeInBytes;
+                existingDocument.SetUpdated();
+
+                unitOfWork.Document.Update(existingDocument);
+                unitOfWork.SaveChange();
+                return ResultViewModel.Success(
+                    "Document updated successfully",
+                    existingDocument);
+            }
+            catch (Exception ex)
+            {
+                return ResultViewModel.FailException(ex);
+            }
         }
-        catch (Exception ex)
-        {
-            return ResultViewModel.FailException(ex);
-        }
-    }
     
     public ResultViewModel DeleteDocument(string id)
     {

--- a/CourseManagement.Service/Services/LessonContentService.cs
+++ b/CourseManagement.Service/Services/LessonContentService.cs
@@ -31,8 +31,8 @@ namespace CourseManagement.Service.Services
         
         public ContentViewModel GetById(string id)
         {
-            // Get lesson by ID
-            var content = unitOfWork.Content.BuildQuery(l => l.LessonId == id).FirstOrDefault();
+            // Get content by content ID
+            var content = unitOfWork.Content.BuildQuery(c => c.ContentId == id).FirstOrDefault();
             if (content == null)
                 return null;
 

--- a/CourseManagement.Service/Services/LessonService.cs
+++ b/CourseManagement.Service/Services/LessonService.cs
@@ -89,15 +89,23 @@ public class LessonService: ILessonService
     {
         try
         {
-            var existingLesson = unitOfWork.Lesson.BuildQuery(l => l.LessonId == lesson.LessonId).FirstOrDefault();
-            existingLesson.LessonId = lesson.LessonId;
+            var existingLesson = unitOfWork.Lesson
+                .BuildQuery(l => l.LessonId == lesson.LessonId)
+                .FirstOrDefault();
+
+            if (existingLesson == null)
+            {
+                return ResultViewModel.Fail("Lesson not found");
+            }
+
             existingLesson.Title = lesson.Title;
             existingLesson.OrderNumber = lesson.OrderNumber;
             existingLesson.ChapterId = lesson.ChapterId;
             existingLesson.Duration = lesson.Duration;
             existingLesson.LessonType = lesson.LessonType;
             existingLesson.IsPreviewable = lesson.IsPreviewable;
-            unitOfWork.Lesson.Update(lesson);
+
+            unitOfWork.Lesson.Update(existingLesson);
             return ResultViewModel.Success("Update lesson by id successfully");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- fix DocumentService.UpdateDocument to update retrieved entity and check null
- fix CategoryService.UpdateCategory to modify existing entity
- fix ChapterService.UpdateChapter to modify existing entity
- fix LessonService.UpdateLesson to modify existing entity
- fix LessonContentService.GetById query to use ContentId

## Testing
- `dotnet build CourseManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469c4c86888328bc1d9f460daacdd6