### PR TITLE
Use ResultViewModel for API controller actions

### DIFF
--- a/CourseManagement.Api/Controllers/CategoryController.cs
+++ b/CourseManagement.Api/Controllers/CategoryController.cs
@@ -1,4 +1,5 @@
 ﻿using CourseManagement.Core.Models;
+using System;
 using System.Collections.Generic;
 using CourseManagement.Core.RequestModels;
 using CourseManagement.Core.ViewModels;
@@ -12,73 +13,108 @@ namespace CourseManagement.Api.Controllers;
 public class CategoryController (ICategoryService categoryService): ControllerBase
 {
     [HttpGet]
-    public IActionResult GetAllCategory()
+    public ResultViewModel GetAllCategory()
     {
-        var result = categoryService.GetAllCategory();
-        var data = (result.Data as IEnumerable<Category>)?.Select(c => new CategoryResponseModel
+        try
         {
-            CategoryId = c.CategoryId,
-            Name = c.Name,
-            Description = c.Description,
-            Icon = c.Icon
-        });
-        result.Data = data;
-        Response.StatusCode = result.Code;
-        return Ok(result);
-    }
-
-    [HttpGet("{id}")]
-    public IActionResult GetCategoryById(string id)
-    {
-        var result = categoryService.GetCategoryById(id);
-        if (result.Data is Category c)
-        {
-            result.Data = new CategoryResponseModel
+            var result = categoryService.GetAllCategory();
+            var data = (result.Data as IEnumerable<Category>)?.Select(c => new CategoryResponseModel
             {
                 CategoryId = c.CategoryId,
                 Name = c.Name,
                 Description = c.Description,
                 Icon = c.Icon
-            };
+            });
+            result.Data = data;
+            Response.StatusCode = result.Code;
+            return result;
         }
-        Response.StatusCode = result.Code;
-        return Ok(result);
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public ResultViewModel GetCategoryById(string id)
+    {
+        try
+        {
+            var result = categoryService.GetCategoryById(id);
+            if (result.Data is Category c)
+            {
+                result.Data = new CategoryResponseModel
+                {
+                    CategoryId = c.CategoryId,
+                    Name = c.Name,
+                    Description = c.Description,
+                    Icon = c.Icon
+                };
+            }
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost]
     public ResultViewModel CreateCategory([FromBody] CategoryRequestModel model)
     {
-        var category = new Category
+        try
         {
-            Name = model.Name,
-            Description = model.Description,
-            Icon = model.Icon
-        };
-        var result = categoryService.CreateCategory(category);
-        Response.StatusCode = result.Code;
-        return result;
+            var category = new Category
+            {
+                Name = model.Name,
+                Description = model.Description,
+                Icon = model.Icon
+            };
+            var result = categoryService.CreateCategory(category);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("{id}")]
     public ResultViewModel UpdateCategory(string id, [FromBody] CategoryRequestModel model)
     {
-        var category = new Category
+        try
         {
-            CategoryId = id,
-            Name = model.Name,
-            Description = model.Description,
-            Icon = model.Icon
-        };
-        var result = categoryService.UpdateCategory(category);
-        Response.StatusCode = result.Code;
-        return result;
+            var category = new Category
+            {
+                CategoryId = id,
+                Name = model.Name,
+                Description = model.Description,
+                Icon = model.Icon
+            };
+            var result = categoryService.UpdateCategory(category);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpDelete("{id}")]
     public ResultViewModel DeleteCategory(string id)
     {
-        var result = categoryService.DeleteCategory(id);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = categoryService.DeleteCategory(id);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 }

--- a/CourseManagement.Api/Controllers/ChapterController.cs
+++ b/CourseManagement.Api/Controllers/ChapterController.cs
@@ -1,4 +1,5 @@
 ﻿using CourseManagement.Core.Models;
+using System;
 using System.Linq;
 using CourseManagement.Core.RequestModels;
 using CourseManagement.Core.ViewModels;
@@ -12,75 +13,113 @@ namespace CourseManagement.Api.Controllers;
 public class ChapterController(IChapterService chapterService):ControllerBase
 {
     [HttpGet]
-    public IActionResult GetAllChapter()
+    public ResultViewModel GetAllChapter()
     {
-        var chapters = chapterService.GetAllChapters()
-            .Select(c => new ChapterResponseModel
+        try
+        {
+            var chapters = chapterService.GetAllChapters()
+                .Select(c => new ChapterResponseModel
+                {
+                    ChapterId = c.ChapterId,
+                    CourseId = c.CourseId,
+                    Title = c.Title,
+                    Description = c.Description,
+                    OrderNumber = c.OrderNumber,
+                    CourseTitle = c.CourseTitle
+                });
+            return ResultViewModel.Success("Get all chapters successfully", chapters);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public ResultViewModel GetChapterById(string id)
+    {
+        try
+        {
+            var c = chapterService.GetChapterById(id);
+            if (c == null)
+            {
+                return ResultViewModel.Fail("Chapter not found");
+            }
+            var chapter = new ChapterResponseModel
             {
                 ChapterId = c.ChapterId,
                 CourseId = c.CourseId,
                 Title = c.Title,
                 Description = c.Description,
-                OrderNumber = c.OrderNumber,
-                CourseTitle = c.CourseTitle
-            });
-        return Ok(chapters);
-    }
-
-    [HttpGet("{id}")]
-    public IActionResult GetChapterById(string id)
-    {
-        var c = chapterService.GetChapterById(id);
-        if (c == null) return NotFound();
-        var chapter = new ChapterResponseModel
+                OrderNumber = c.OrderNumber
+            };
+            return ResultViewModel.Success("Get chapter by id successfully", chapter);
+        }
+        catch (Exception ex)
         {
-            ChapterId = c.ChapterId,
-            CourseId = c.CourseId,
-            Title = c.Title,
-            Description = c.Description,
-            OrderNumber = c.OrderNumber
-        };
-        return Ok(chapter);
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost]
     public ResultViewModel CreateChapter([FromBody] ChapterRequestModel model)
     {
-        var chapter = new Chapter
+        try
         {
-            CourseId = model.CourseId,
-            Title = model.Title,
-            Description = model.Description,
-            FullDescription = model.FullDescription,
-            OrderNumber = model.OrderNumber
-        };
-        var result = chapterService.CreateChapter(chapter);
-        Response.StatusCode = result.Code;
-        return result;
+            var chapter = new Chapter
+            {
+                CourseId = model.CourseId,
+                Title = model.Title,
+                Description = model.Description,
+                FullDescription = model.FullDescription,
+                OrderNumber = model.OrderNumber
+            };
+            var result = chapterService.CreateChapter(chapter);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("{id}")]
     public ResultViewModel UpdateChapter(string id, [FromBody] ChapterRequestModel model)
     {
-        var chapter = new Chapter
+        try
         {
-            ChapterId = id,
-            CourseId = model.CourseId,
-            Title = model.Title,
-            Description = model.Description,
-            FullDescription = model.FullDescription,
-            OrderNumber = model.OrderNumber
-        };
-        var result = chapterService.UpdateChapter(chapter);
-        Response.StatusCode = result.Code;
-        return result;
+            var chapter = new Chapter
+            {
+                ChapterId = id,
+                CourseId = model.CourseId,
+                Title = model.Title,
+                Description = model.Description,
+                FullDescription = model.FullDescription,
+                OrderNumber = model.OrderNumber
+            };
+            var result = chapterService.UpdateChapter(chapter);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpDelete("{id}")]
     public ResultViewModel DeleteChapter(string id)
     {
-        var result = chapterService.DeleteChapter(id);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = chapterService.DeleteChapter(id);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 }

--- a/CourseManagement.Api/Controllers/CourseController.cs
+++ b/CourseManagement.Api/Controllers/CourseController.cs
@@ -1,4 +1,5 @@
 ﻿using CourseManagement.Core.Models;
+using System;
 using System.Linq;
 using CourseManagement.Core.RequestModels;
 using CourseManagement.Core.ViewModels;
@@ -12,10 +13,45 @@ namespace CourseManagement.Api.Controllers;
 public class CourseController(ICourseService courseService) : ControllerBase
 {
     [HttpGet]
-    public IActionResult GetAllCourses()
+    public ResultViewModel GetAllCourses()
     {
-        var courses = courseService.GetAllCourse()
-            .Select(c => new CourseResponseModel
+        try
+        {
+            var courses = courseService.GetAllCourse()
+                .Select(c => new CourseResponseModel
+                {
+                    CourseId = c.CourseId,
+                    Title = c.Title,
+                    Description = c.Description,
+                    Level = c.Level,
+                    Duration = c.Duration,
+                    Language = c.Language,
+                    ThumbnailUrl = c.ThumbnailUrl,
+                    Price = c.Price,
+                    IsFree = c.IsFree,
+                    AuthorName = c.AuthorName,
+                    CategoryId = c.CategoryId,
+                    CategoryName = c.CategoryName
+                });
+            return ResultViewModel.Success("Get all courses successfully", courses);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public ResultViewModel GetCourseById(string id)
+    {
+        try
+        {
+            var c = courseService.GetCourseById(id);
+            if (c == null)
+            {
+                return ResultViewModel.Fail("Course not found");
+            }
+            var course = new CourseResponseModel
             {
                 CourseId = c.CourseId,
                 Title = c.Title,
@@ -29,113 +65,133 @@ public class CourseController(ICourseService courseService) : ControllerBase
                 AuthorName = c.AuthorName,
                 CategoryId = c.CategoryId,
                 CategoryName = c.CategoryName
-            });
-        return Ok(courses);
-    }
-
-    [HttpGet("{id}")]
-    public IActionResult GetCourseById(string id)
-    {
-        var c = courseService.GetCourseById(id);
-        if (c == null) return NotFound();
-        var course = new CourseResponseModel
+            };
+            return ResultViewModel.Success("Get course by id successfully", course);
+        }
+        catch (Exception ex)
         {
-            CourseId = c.CourseId,
-            Title = c.Title,
-            Description = c.Description,
-            Level = c.Level,
-            Duration = c.Duration,
-            Language = c.Language,
-            ThumbnailUrl = c.ThumbnailUrl,
-            Price = c.Price,
-            IsFree = c.IsFree,
-            AuthorName = c.AuthorName,
-            CategoryId = c.CategoryId,
-            CategoryName = c.CategoryName
-        };
-        return Ok(course);
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost]
     public ResultViewModel CreateCourse([FromBody] CourseRequestModel model)
     {
-        var course = new Course
+        try
         {
-            Title = model.Title,
-            Description = model.Description,
-            FullDescription = model.FullDescription,
-            Level = model.Level,
-            Duration = model.Duration,
-            Language = model.Language,
-            ThumbnailUrl = model.ThumbnailUrl,
-            Price = model.Price,
-            IsFree = model.IsFree,
-            AuthorName = model.AuthorName,
-            CategoryId = model.CategoryId
-        };
-        var result = courseService.CreateCourse(course);
-        Response.StatusCode = result.Code;
-        return result;
+            var course = new Course
+            {
+                Title = model.Title,
+                Description = model.Description,
+                FullDescription = model.FullDescription,
+                Level = model.Level,
+                Duration = model.Duration,
+                Language = model.Language,
+                ThumbnailUrl = model.ThumbnailUrl,
+                Price = model.Price,
+                IsFree = model.IsFree,
+                AuthorName = model.AuthorName,
+                CategoryId = model.CategoryId
+            };
+            var result = courseService.CreateCourse(course);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("{id}")]
     public ResultViewModel UpdateCourse(string id, [FromBody] CourseRequestModel model)
     {
-        var course = new CourseViewModel
+        try
         {
-            CourseId = id,
-            Title = model.Title,
-            Description = model.Description,
-            FullDescription = model.FullDescription,
-            Level = model.Level,
-            Duration = model.Duration,
-            Language = model.Language,
-            ThumbnailUrl = model.ThumbnailUrl,
-            Price = model.Price,
-            IsFree = model.IsFree,
-            AuthorName = model.AuthorName,
-            CategoryId = model.CategoryId
-        };
-        var result = courseService.UpdateCourse(course);
-        Response.StatusCode = result.Code;
-        return result;
+            var course = new CourseViewModel
+            {
+                CourseId = id,
+                Title = model.Title,
+                Description = model.Description,
+                FullDescription = model.FullDescription,
+                Level = model.Level,
+                Duration = model.Duration,
+                Language = model.Language,
+                ThumbnailUrl = model.ThumbnailUrl,
+                Price = model.Price,
+                IsFree = model.IsFree,
+                AuthorName = model.AuthorName,
+                CategoryId = model.CategoryId
+            };
+            var result = courseService.UpdateCourse(course);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpDelete("{id}")]
     public ResultViewModel DeleteCourse(string id)
     {
-        var result = courseService.DeleteCourse(id);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = courseService.DeleteCourse(id);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpGet("category/{categoryId}")]
-    public IActionResult GetAllCoursesByCategoryId(string categoryId)
+    public ResultViewModel GetAllCoursesByCategoryId(string categoryId)
     {
-        var courses = courseService.GetAllCoursesByCategoryId(categoryId);
-        return Ok(courses);
+        try
+        {
+            var courses = courseService.GetAllCoursesByCategoryId(categoryId);
+            return courses;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpGet("lesson/{lessonId}")]
-    public IActionResult GetAllCoursesByLessonId(string lessonId)
+    public ResultViewModel GetAllCoursesByLessonId(string lessonId)
     {
-        var c = courseService.GetCourseByLessonId(lessonId);
-        if (c == null) return NotFound();
-        var course = new CourseResponseModel
+        try
         {
-            CourseId = c.CourseId,
-            Title = c.Title,
-            Description = c.Description,
-            Level = c.Level,
-            Duration = c.Duration,
-            Language = c.Language,
-            ThumbnailUrl = c.ThumbnailUrl,
-            Price = c.Price,
-            IsFree = c.IsFree,
-            AuthorName = c.AuthorName,
-            CategoryId = c.CategoryId,
-            CategoryName = c.CategoryName
-        };
-        return Ok(course);
+            var c = courseService.GetCourseByLessonId(lessonId);
+            if (c == null)
+            {
+                return ResultViewModel.Fail("Course not found");
+            }
+            var course = new CourseResponseModel
+            {
+                CourseId = c.CourseId,
+                Title = c.Title,
+                Description = c.Description,
+                Level = c.Level,
+                Duration = c.Duration,
+                Language = c.Language,
+                ThumbnailUrl = c.ThumbnailUrl,
+                Price = c.Price,
+                IsFree = c.IsFree,
+                AuthorName = c.AuthorName,
+                CategoryId = c.CategoryId,
+                CategoryName = c.CategoryName
+            };
+            return ResultViewModel.Success("Get course by lesson id successfully", course);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 }

--- a/CourseManagement.Api/Controllers/LessonContentController.cs
+++ b/CourseManagement.Api/Controllers/LessonContentController.cs
@@ -12,86 +12,141 @@ namespace CourseManagement.Api.Controllers;
 public class LessonContentController(ILessonContentService lessonContentService) : ControllerBase
 {
     [HttpGet("lesson/{lessonId}")]
-    public IActionResult GetLessonContentByLessonId(string lessonId)
+    public ResultViewModel GetLessonContentByLessonId(string lessonId)
     {
-        var content = lessonContentService.GetContentByLessonId(lessonId);
-        if (content == null) return NotFound();
-        var result = new ContentResponseModel
+        try
         {
-            ContentId = content.ContentId,
-            LessonId = content.LessonId,
-            MainContent = content.MainContent,
-            Summary = content.Summary
-        };
-        return Ok(result);
+            var content = lessonContentService.GetContentByLessonId(lessonId);
+            if (content == null)
+            {
+                return ResultViewModel.Fail("Content not found");
+            }
+            var result = new ContentResponseModel
+            {
+                ContentId = content.ContentId,
+                LessonId = content.LessonId,
+                MainContent = content.MainContent,
+                Summary = content.Summary
+            };
+            return ResultViewModel.Success("Get content by lesson id successfully", result);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpGet("{id}")]
-    public IActionResult GetContentById(string id)
+    public ResultViewModel GetContentById(string id)
     {
-        var c = lessonContentService.GetById(id);
-        if (c == null) return NotFound();
-        var content = new ContentResponseModel
+        try
         {
-            ContentId = c.ContentId,
-            LessonId = c.LessonId,
-            MainContent = c.MainContent,
-            Summary = c.Summary
-        };
-        return Ok(content);
+            var c = lessonContentService.GetById(id);
+            if (c == null)
+            {
+                return ResultViewModel.Fail("Content not found");
+            }
+            var content = new ContentResponseModel
+            {
+                ContentId = c.ContentId,
+                LessonId = c.LessonId,
+                MainContent = c.MainContent,
+                Summary = c.Summary
+            };
+            return ResultViewModel.Success("Get content by id successfully", content);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost]
     public ResultViewModel AddContent([FromBody] ContentRequestModel model)
     {
-        var content = new ContentViewModel
+        try
         {
-            ContentId = Guid.NewGuid().ToString(),
-            LessonId = model.LessonId,
-            MainContent = model.MainContent,
-            Summary = model.Summary
-        };
-        var result = lessonContentService.CreateContent(content);
-        Response.StatusCode = result.Code;
-        return result;
+            var content = new ContentViewModel
+            {
+                ContentId = Guid.NewGuid().ToString(),
+                LessonId = model.LessonId,
+                MainContent = model.MainContent,
+                Summary = model.Summary
+            };
+            var result = lessonContentService.CreateContent(content);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("{id}")]
     public ResultViewModel UpdateContent(string id, [FromBody] ContentRequestModel model)
     {
-        var content = new ContentViewModel
+        try
         {
-            ContentId = id,
-            LessonId = model.LessonId,
-            MainContent = model.MainContent,
-            Summary = model.Summary
-        };
-        var result = lessonContentService.UpdateContent(content);
-        Response.StatusCode = result.Code;
-        return result;
+            var content = new ContentViewModel
+            {
+                ContentId = id,
+                LessonId = model.LessonId,
+                MainContent = model.MainContent,
+                Summary = model.Summary
+            };
+            var result = lessonContentService.UpdateContent(content);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpDelete("{id}")]
     public ResultViewModel DeleteContent(string id)
     {
-        var result = lessonContentService.DeleteContent(id);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = lessonContentService.DeleteContent(id);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("UpdateSummaryContent/{id}")]
     public ResultViewModel UpdateSummaryContent(string id, [FromBody] ContentRequestModel content)
     {
-        var result = lessonContentService.UpdateSummary(id, content.Summary);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = lessonContentService.UpdateSummary(id, content.Summary);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("UpdateMainContent/{id}")]
     public ResultViewModel UpdateMainContent(string id, [FromBody] ContentRequestModel content)
     {
-        var result = lessonContentService.UpdateMainContent(id, content.MainContent);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = lessonContentService.UpdateMainContent(id, content.MainContent);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 }

--- a/CourseManagement.Api/Controllers/LessonController.cs
+++ b/CourseManagement.Api/Controllers/LessonController.cs
@@ -12,12 +12,46 @@ namespace CourseManagement.Api.Controllers;
 public class LessonController(ILessonService lessonService): ControllerBase
 {
     [HttpGet]
-    public IActionResult GetAllLessons()
+    public ResultViewModel GetAllLessons()
     {
-        var result = lessonService.GetAllLessons();
-        if (result.Data is IEnumerable<LessonViewModel> list)
+        try
         {
-            result.Data = list.Select(l => new LessonResponseModel
+            var result = lessonService.GetAllLessons();
+            if (result.Data is IEnumerable<LessonViewModel> list)
+            {
+                result.Data = list.Select(l => new LessonResponseModel
+                {
+                    LessonId = l.LessonId,
+                    Title = l.Title,
+                    OrderNumber = l.OrderNumber,
+                    ChapterId = l.ChapterId,
+                    Duration = l.Duration,
+                    LessonType = l.LessonType,
+                    IsPreviewable = l.IsPreviewable,
+                    ChapterTitle = l.ChapterTitle,
+                    CourseTitle = l.CourseTitle
+                });
+            }
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public ResultViewModel GetLessonById(string id)
+    {
+        try
+        {
+            var l = lessonService.GetLessonById(id);
+            if (l == null)
+            {
+                return ResultViewModel.Fail("Lesson not found");
+            }
+            var lesson = new LessonResponseModel
             {
                 LessonId = l.LessonId,
                 Title = l.Title,
@@ -28,74 +62,78 @@ public class LessonController(ILessonService lessonService): ControllerBase
                 IsPreviewable = l.IsPreviewable,
                 ChapterTitle = l.ChapterTitle,
                 CourseTitle = l.CourseTitle
-            });
+            };
+            return ResultViewModel.Success("Get lesson by id successfully", lesson);
         }
-        Response.StatusCode = result.Code;
-        return Ok(result);
-    }
-
-    [HttpGet("{id}")]
-    public IActionResult GetLessonById(string id)
-    {
-        var l = lessonService.GetLessonById(id);
-        if (l == null) return NotFound();
-        var lesson = new LessonResponseModel
+        catch (Exception ex)
         {
-            LessonId = l.LessonId,
-            Title = l.Title,
-            OrderNumber = l.OrderNumber,
-            ChapterId = l.ChapterId,
-            Duration = l.Duration,
-            LessonType = l.LessonType,
-            IsPreviewable = l.IsPreviewable,
-            ChapterTitle = l.ChapterTitle,
-            CourseTitle = l.CourseTitle
-        };
-        return Ok(lesson);
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost]
     public ResultViewModel CreateLesson([FromBody] LessonRequestModel model)
     {
-        var lesson = new Lesson
+        try
         {
-            LessonId = Guid.NewGuid().ToString(),
-            Title = model.Title,
-            OrderNumber = model.OrderNumber,
-            ChapterId = model.ChapterId,
-            Duration = model.Duration,
-            LessonType = model.LessonType,
-            IsPreviewable = model.IsPreviewable
-        };
-        var result = lessonService.CreateLesson(lesson);
-        Response.StatusCode = result.Code;
-        return result;
+            var lesson = new Lesson
+            {
+                LessonId = Guid.NewGuid().ToString(),
+                Title = model.Title,
+                OrderNumber = model.OrderNumber,
+                ChapterId = model.ChapterId,
+                Duration = model.Duration,
+                LessonType = model.LessonType,
+                IsPreviewable = model.IsPreviewable
+            };
+            var result = lessonService.CreateLesson(lesson);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPut("{id}")]
     public ResultViewModel UpdateLesson(string id, [FromBody] LessonRequestModel model)
     {
-        var lesson = new Lesson
+        try
         {
-            LessonId = id,
-            Title = model.Title,
-            OrderNumber = model.OrderNumber,
-            ChapterId = model.ChapterId,
-            Duration = model.Duration,
-            LessonType = model.LessonType,
-            IsPreviewable = model.IsPreviewable
-        };
-        var result = lessonService.UpdateLesson(lesson);
-        Response.StatusCode = result.Code;
-        return result;
+            var lesson = new Lesson
+            {
+                LessonId = id,
+                Title = model.Title,
+                OrderNumber = model.OrderNumber,
+                ChapterId = model.ChapterId,
+                Duration = model.Duration,
+                LessonType = model.LessonType,
+                IsPreviewable = model.IsPreviewable
+            };
+            var result = lessonService.UpdateLesson(lesson);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpDelete("{id}")]
     public ResultViewModel DeleteLesson(string id)
     {
-        var result = lessonService.DeleteLesson(id);
-        Response.StatusCode = result.Code;
-        return result;
+        try
+        {
+            var result = lessonService.DeleteLesson(id);
+            Response.StatusCode = result.Code;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
     
 }

--- a/CourseManagement.Api/Controllers/VideoController.cs
+++ b/CourseManagement.Api/Controllers/VideoController.cs
@@ -14,95 +14,12 @@ namespace CourseManagement.Api.Controllers;
 public class VideoController(IVideoService videoService) : ControllerBase
 {
     [HttpGet]
-    public async Task<IActionResult> GetAllVideos()
+    public async Task<ResultViewModel> GetAllVideos()
     {
-        var videos = await videoService.GetAllVideos();
-        var result = videos.Select(v => new VideoResponseModel
+        try
         {
-            VideoId = v.VideoId,
-            LessonId = v.LessonId,
-            Title = v.Title,
-            Url = v.Url,
-            Duration = v.Duration,
-            Provider = v.Provider,
-            LessonTitle = v.LessonTitle,
-            ChapterTitle = v.ChapterTitle,
-            CourseTitle = v.CourseTitle
-        });
-        return Ok(result);
-    }
-
-    [HttpGet("{id}")]
-    public async Task<IActionResult> GetVideoById(string id)
-    {
-        var v = await videoService.GetById(id);
-        if (v == null) return NotFound();
-        var video = new VideoResponseModel
-        {
-            VideoId = v.VideoId,
-            LessonId = v.LessonId,
-            Title = v.Title,
-            Url = v.Url,
-            Duration = v.Duration,
-            Provider = v.Provider,
-            LessonTitle = v.LessonTitle,
-            ChapterTitle = v.ChapterTitle,
-            CourseTitle = v.CourseTitle
-        };
-        return Ok(video);
-    }
-
-    [HttpPost]
-    public async Task<IActionResult> AddVideo([FromBody] VideoRequestModel model)
-    {
-        var video = new VideoViewModel
-        {
-            VideoId = Guid.NewGuid().ToString(),
-            LessonId = model.LessonId,
-            Title = model.Title,
-            Url = model.Url,
-            Duration = model.Duration,
-            Provider = model.Provider
-        };
-        await videoService.Create(video);
-        return Ok();
-    }
-
-    [HttpPut("{id}")]
-    public async Task<IActionResult> UpdateVideo(string id, [FromBody] VideoRequestModel model)
-    {
-        var video = new VideoViewModel
-        {
-            VideoId = id,
-            LessonId = model.LessonId,
-            Title = model.Title,
-            Url = model.Url,
-            Duration = model.Duration,
-            Provider = model.Provider
-        };
-        await videoService.Update(video);
-        return Ok();
-    }
-
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> DeleteVideo(string id)
-    {
-        await videoService.Delete(id);
-        return Ok();
-    }
-
-    // [HttpGet]
-    // public IActionResult GetVideoByLessonId(string id)
-    // {
-    //     var video = videoService.GetByLessonId(id);
-    //     return Ok(video);
-    // }
-
-    [HttpGet("lesson/{lessonId}")]
-    public IActionResult GetAllVideosByLessonId(string lessonId)
-    {
-        var videos = videoService.GetAllVideosByLessonId(lessonId)
-            .Select(v => new VideoResponseModel
+            var videos = await videoService.GetAllVideos();
+            var result = videos.Select(v => new VideoResponseModel
             {
                 VideoId = v.VideoId,
                 LessonId = v.LessonId,
@@ -114,28 +31,163 @@ public class VideoController(IVideoService videoService) : ControllerBase
                 ChapterTitle = v.ChapterTitle,
                 CourseTitle = v.CourseTitle
             });
-        return Ok(videos);
+            return ResultViewModel.Success("Get all videos successfully", result);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ResultViewModel> GetVideoById(string id)
+    {
+        try
+        {
+            var v = await videoService.GetById(id);
+            if (v == null)
+            {
+                return ResultViewModel.Fail("Video not found");
+            }
+            var video = new VideoResponseModel
+            {
+                VideoId = v.VideoId,
+                LessonId = v.LessonId,
+                Title = v.Title,
+                Url = v.Url,
+                Duration = v.Duration,
+                Provider = v.Provider,
+                LessonTitle = v.LessonTitle,
+                ChapterTitle = v.ChapterTitle,
+                CourseTitle = v.CourseTitle
+            };
+            return ResultViewModel.Success("Get video by id successfully", video);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpPost]
+    public async Task<ResultViewModel> AddVideo([FromBody] VideoRequestModel model)
+    {
+        try
+        {
+            var video = new VideoViewModel
+            {
+                VideoId = Guid.NewGuid().ToString(),
+                LessonId = model.LessonId,
+                Title = model.Title,
+                Url = model.Url,
+                Duration = model.Duration,
+                Provider = model.Provider
+            };
+            await videoService.Create(video);
+            return ResultViewModel.Success("Video created successfully");
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ResultViewModel> UpdateVideo(string id, [FromBody] VideoRequestModel model)
+    {
+        try
+        {
+            var video = new VideoViewModel
+            {
+                VideoId = id,
+                LessonId = model.LessonId,
+                Title = model.Title,
+                Url = model.Url,
+                Duration = model.Duration,
+                Provider = model.Provider
+            };
+            await videoService.Update(video);
+            return ResultViewModel.Success("Video updated successfully");
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<ResultViewModel> DeleteVideo(string id)
+    {
+        try
+        {
+            await videoService.Delete(id);
+            return ResultViewModel.Success("Video deleted successfully");
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
+    }
+
+    // [HttpGet]
+    // public IActionResult GetVideoByLessonId(string id)
+    // {
+    //     var video = videoService.GetByLessonId(id);
+    //     return Ok(video);
+    // }
+
+    [HttpGet("lesson/{lessonId}")]
+    public ResultViewModel GetAllVideosByLessonId(string lessonId)
+    {
+        try
+        {
+            var videos = videoService.GetAllVideosByLessonId(lessonId)
+                .Select(v => new VideoResponseModel
+                {
+                    VideoId = v.VideoId,
+                    LessonId = v.LessonId,
+                    Title = v.Title,
+                    Url = v.Url,
+                    Duration = v.Duration,
+                    Provider = v.Provider,
+                    LessonTitle = v.LessonTitle,
+                    ChapterTitle = v.ChapterTitle,
+                    CourseTitle = v.CourseTitle
+                });
+            return ResultViewModel.Success("Get videos by lesson id successfully", videos);
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 
     [HttpPost("uploadVideo")]
-    public async Task<IActionResult> UploadAndCreateVideo([FromForm]VideoRequestModel requestModel)
+    public async Task<ResultViewModel> UploadAndCreateVideo([FromForm]VideoRequestModel requestModel)
     {
-        var model = new VideoViewModel()
+        try
         {
-            LessonId = requestModel.LessonId,
-            Title = requestModel.Title,
-            Url = requestModel.Url,
-            Duration = requestModel.Duration,
-            Provider = requestModel.Provider,
-            VideoFile = requestModel.VideoFile,
-        };
-        string savedUrl = string.Empty;
-        await videoService.UploadAndCreateVideo(
-            model,
-            model.VideoFile,
-            Directory.GetCurrentDirectory(),
-            url => savedUrl = url
-        );
-        return Ok();
+            var model = new VideoViewModel()
+            {
+                LessonId = requestModel.LessonId,
+                Title = requestModel.Title,
+                Url = requestModel.Url,
+                Duration = requestModel.Duration,
+                Provider = requestModel.Provider,
+                VideoFile = requestModel.VideoFile,
+            };
+            string savedUrl = string.Empty;
+            await videoService.UploadAndCreateVideo(
+                model,
+                model.VideoFile,
+                Directory.GetCurrentDirectory(),
+                url => savedUrl = url
+            );
+            return ResultViewModel.Success("Video uploaded successfully");
+        }
+        catch (Exception ex)
+        {
+            return ResultViewModel.FailException(ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- unify API controller methods to return `ResultViewModel`
- wrap actions in try/catch blocks and return appropriate failure responses

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848103894e88328bed1a9c3e374295b